### PR TITLE
Fix Hot-Reload Issue

### DIFF
--- a/lib/map_view.dart
+++ b/lib/map_view.dart
@@ -42,13 +42,13 @@ class MapViewState extends State<MapView> {
   @override
   Widget build(BuildContext context) {
     return new LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constrains) {
-      if (constrains.biggest.isEmpty) {
+        builder: (BuildContext context, BoxConstraints constraints) {
+      if (constraints.biggest.isEmpty) {
         return new Container();
       }
 
       if (!_initialized) {
-        _createMapView(constrains.biggest, widget.options);
+        _createMapView(constraints.biggest, widget.options);
 
         _initialized = true;
         return new Container();

--- a/lib/map_view.dart
+++ b/lib/map_view.dart
@@ -66,9 +66,9 @@ class MapViewState extends State<MapView> {
   }
 
   void _onDoubleTap() {
-    widget.map.getZoom().then((zoom) {
+    widget.map.getZoom(_textureId).then((zoom) {
       zoom++;
-      widget.map.zoom(zoom, _size.width / 2, _size.height / 2, 350);
+      widget.map.zoom(_textureId, zoom, _size.width / 2, _size.height / 2, 350);
     });
   }
 
@@ -79,7 +79,7 @@ class MapViewState extends State<MapView> {
 
   void _onScaleUpdate(ScaleUpdateDetails details) {
     final Offset delta = details.focalPoint - _scaleStartFocal;
-    widget.map.moveBy(delta.dx, delta.dy, 0);
+    widget.map.moveBy(_textureId, delta.dx, delta.dy, 0);
 
     if (details.scale != 1.0) {
       RenderBox renderBox = context.findRenderObject();
@@ -87,7 +87,7 @@ class MapViewState extends State<MapView> {
 
       double newZoom = _zoomLevel(details.scale);
       double _zoomBy = newZoom - _zoom;
-      widget.map.zoomBy(_zoomBy, focalPoint.dx, focalPoint.dy, 0);
+      widget.map.zoomBy(_textureId, _zoomBy, focalPoint.dx, focalPoint.dy, 0);
 
       _zoom = newZoom;
     }

--- a/lib/mapbox_map.dart
+++ b/lib/mapbox_map.dart
@@ -10,7 +10,8 @@ class Style {
   static final String light = "mapbox://styles/mapbox/light-v9";
   static final String dark = "mapbox://styles/mapbox/dark-v9";
   static final String satellite = "mapbox://styles/mapbox/satellite-v9";
-  static final String satelliteStreets = "mapbox://styles/mapbox/satellite-streets-v10";
+  static final String satelliteStreets =
+      "mapbox://styles/mapbox/satellite-streets-v10";
   static final String trafficDay = "mapbox://styles/mapbox/traffic-day-v2";
   static final String trafficNight = "mapbox://styles/mapbox/traffic-night-v2";
 }
@@ -19,13 +20,10 @@ class LatLng {
   final double lat;
   final double lng;
 
-  LatLng({ this.lat, this.lng});
+  LatLng({this.lat, this.lng});
 
   Map<String, Object> toMap() {
-    return {
-      "lat": lat,
-      "lng": lng
-    };
+    return {"lat": lat, "lng": lng};
   }
 }
 
@@ -35,22 +33,17 @@ class CameraPosition {
   final double bearing;
   final double tilt;
 
-  CameraPosition({ this.target, this.zoom, this.bearing, this.tilt });
+  CameraPosition({this.target, this.zoom, this.bearing, this.tilt});
 
-  CameraPosition copyWith({
-    LatLng target,
-    double zoom,
-    double bearing,
-    double tilt
-  }) {
-
+  CameraPosition copyWith(
+      {LatLng target, double zoom, double bearing, double tilt}) {
     LatLng newTarget = target ?? this.target;
     double newZoom = zoom ?? this.zoom;
     double newBearing = bearing ?? this.bearing;
     double newTilt = tilt ?? this.tilt;
 
-    return new CameraPosition(target: newTarget,
-        zoom: newZoom, bearing: newBearing, tilt: newTilt);
+    return new CameraPosition(
+        target: newTarget, zoom: newZoom, bearing: newBearing, tilt: newTilt);
   }
 
   Map<String, Object> toMap() {
@@ -67,20 +60,16 @@ class MapboxMapOptions {
   final String style;
   final CameraPosition camera;
 
-  MapboxMapOptions({ this.style, this.camera });
+  MapboxMapOptions({this.style, this.camera});
 
   Map<String, Object> toMap() {
-    return {
-      "style": style,
-      "camera": camera.toMap()
-    };
+    return {"style": style, "camera": camera.toMap()};
   }
 }
 
-class MapboxMap  {
-  int _textureId;
-
-  Future<int> create({double width, double height, MapboxMapOptions options}) async {
+class MapboxMap {
+  Future<int> create(
+      {double width, double height, MapboxMapOptions options}) async {
     try {
       final Map<Object, Object> reply = await _channel.invokeMethod(
         'create',
@@ -90,16 +79,15 @@ class MapboxMap  {
           'options': options.toMap()
         },
       );
-      _textureId = reply['textureId'];
 
-      return new Future.value(_textureId);
-
+      return new Future.value(reply['textureId']);
     } on PlatformException catch (e) {
       return new Future.error(e);
     }
   }
 
-  Future<Null> moveBy(double dx, double dy, int duration) async {
+  Future<Null> moveBy(
+      int _textureId, double dx, double dy, int duration) async {
     try {
       await _channel.invokeMethod(
         'moveBy',
@@ -115,7 +103,8 @@ class MapboxMap  {
     }
   }
 
-  Future<Null> zoom(double zoom, double x, double y, int duration) async {
+  Future<Null> zoom(
+      int _textureId, double zoom, double x, double y, int duration) async {
     try {
       await _channel.invokeMethod(
         'zoom',
@@ -132,7 +121,8 @@ class MapboxMap  {
     }
   }
 
-  Future<Null> zoomBy(double zoomBy, double x, double y, int duration) async {
+  Future<Null> zoomBy(
+      int _textureId, double zoomBy, double x, double y, int duration) async {
     try {
       await _channel.invokeMethod(
         'zoomBy',
@@ -149,28 +139,23 @@ class MapboxMap  {
     }
   }
 
-  Future<double> getZoom() async {
+  Future<double> getZoom(int _textureId) async {
     try {
       final Map<Object, Object> reply = await _channel.invokeMethod(
         'getZoom',
-        <String, Object>{
-          'textureId': _textureId
-        },
+        <String, Object>{'textureId': _textureId},
       );
       return reply['zoom'];
-
     } on PlatformException catch (e) {
       return new Future.error(e);
     }
   }
 
-  Future<Null> dispose() async {
+  Future<Null> dispose(int _textureId) async {
     try {
       await _channel.invokeMethod(
         'dispose',
-        <String, Object>{
-          'textureId': _textureId
-        },
+        <String, Object>{'textureId': _textureId},
       );
     } on PlatformException catch (e) {
       return new Future.error(e);


### PR DESCRIPTION
Currently a hot-reload will cause a Java exception to be thrown on any event as the theoretically stateless class MapView is holding the state of which _textureId to interact with.

E/MethodChannel#com.mapbox/flutter_mapbox(18191): Failed to handle method call
E/MethodChannel#com.mapbox/flutter_mapbox(18191): java.lang.NullPointerException: Attempt to invoke virtual method 'long java.lang.Number.longValue()' on a null object reference
E/MethodChannel#com.mapbox/flutter_mapbox(18191): at com.mapbox.flutter.FlutterMapboxPlugin.textureIdOfCall(FlutterMapboxPlugin.java:224)

This change pulls the _textureId state up to the StatefulWidget component which will preserve _textureId state over hot-reload.