### PR TITLE
Fix Hot-Reload Issue

### DIFF
--- a/lib/map_view.dart
+++ b/lib/map_view.dart
@@ -66,9 +66,9 @@ class MapViewState extends State<MapView> {
   }
 
   void _onDoubleTap() {
-    widget.map.getZoom().then((zoom) {
+    widget.map.getZoom(_textureId).then((zoom) {
       zoom++;
-      widget.map.zoom(zoom, _size.width / 2, _size.height / 2, 350);
+      widget.map.zoom(_textureId, zoom, _size.width / 2, _size.height / 2, 350);
     });
   }
 
@@ -79,7 +79,7 @@ class MapViewState extends State<MapView> {
 
   void _onScaleUpdate(ScaleUpdateDetails details) {
     final Offset delta = details.focalPoint - _scaleStartFocal;
-    widget.map.moveBy(delta.dx, delta.dy, 0);
+    widget.map.moveBy(_textureId, delta.dx, delta.dy, 0);
 
     if (details.scale != 1.0) {
       RenderBox renderBox = context.findRenderObject();
@@ -87,7 +87,7 @@ class MapViewState extends State<MapView> {
 
       double newZoom = _zoomLevel(details.scale);
       double _zoomBy = newZoom - _zoom;
-      widget.map.zoomBy(_zoomBy, focalPoint.dx, focalPoint.dy, 0);
+      widget.map.zoomBy(_textureId, _zoomBy, focalPoint.dx, focalPoint.dy, 0);
 
       _zoom = newZoom;
     }

--- a/lib/mapbox_map.dart
+++ b/lib/mapbox_map.dart
@@ -78,8 +78,6 @@ class MapboxMapOptions {
 }
 
 class MapboxMap  {
-  int _textureId;
-
   Future<int> create({double width, double height, MapboxMapOptions options}) async {
     try {
       final Map<Object, Object> reply = await _channel.invokeMethod(
@@ -90,16 +88,15 @@ class MapboxMap  {
           'options': options.toMap()
         },
       );
-      _textureId = reply['textureId'];
 
-      return new Future.value(_textureId);
+      return new Future.value(reply['textureId']);
 
     } on PlatformException catch (e) {
       return new Future.error(e);
     }
   }
 
-  Future<Null> moveBy(double dx, double dy, int duration) async {
+  Future<Null> moveBy(int _textureId, double dx, double dy, int duration) async {
     try {
       await _channel.invokeMethod(
         'moveBy',
@@ -115,7 +112,7 @@ class MapboxMap  {
     }
   }
 
-  Future<Null> zoom(double zoom, double x, double y, int duration) async {
+  Future<Null> zoom(int _textureId, double zoom, double x, double y, int duration) async {
     try {
       await _channel.invokeMethod(
         'zoom',
@@ -132,7 +129,7 @@ class MapboxMap  {
     }
   }
 
-  Future<Null> zoomBy(double zoomBy, double x, double y, int duration) async {
+  Future<Null> zoomBy(int _textureId, double zoomBy, double x, double y, int duration) async {
     try {
       await _channel.invokeMethod(
         'zoomBy',
@@ -149,7 +146,7 @@ class MapboxMap  {
     }
   }
 
-  Future<double> getZoom() async {
+  Future<double> getZoom(int _textureId) async {
     try {
       final Map<Object, Object> reply = await _channel.invokeMethod(
         'getZoom',
@@ -164,7 +161,7 @@ class MapboxMap  {
     }
   }
 
-  Future<Null> dispose() async {
+  Future<Null> dispose(int _textureId) async {
     try {
       await _channel.invokeMethod(
         'dispose',


### PR DESCRIPTION
Currently a hot-reload will cause a Java exception to be thrown on any event as the theoretically stateless class MapView is holding the state of which _textureId to interact with.

E/MethodChannel#com.mapbox/flutter_mapbox(18191): Failed to handle method call
E/MethodChannel#com.mapbox/flutter_mapbox(18191): java.lang.NullPointerException: Attempt to invoke virtual method 'long java.lang.Number.longValue()' on a null object reference
E/MethodChannel#com.mapbox/flutter_mapbox(18191): at com.mapbox.flutter.FlutterMapboxPlugin.textureIdOfCall(FlutterMapboxPlugin.java:224)

This change pulls the _textureId state up to the StatefulWidget component which will preserve _textureId state over hot-reload.