### PR TITLE
Add example overview

### DIFF
--- a/example/lib/flutter_animation.dart
+++ b/example/lib/flutter_animation.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_mapbox/controller.dart';
+import 'package:flutter_mapbox/overlay.dart';
+
+class AnimationDemo extends StatefulWidget {
+  @override
+  _AnimationDemoState createState() => new _AnimationDemoState();
+}
+
+class _AnimationDemoState extends State<AnimationDemo> {
+
+  final MapboxOverlayController controller = new MapboxOverlayController();
+
+  bool _visible = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      appBar: new AppBar(
+        title: new Text('Flutter Animation Demo'),
+      ),
+      body: new Container(
+        child: new AnimatedOpacity(
+          // If the Widget should be visible, animate to 1.0 (fully visible). If
+          // the Widget should be hidden, animate to 0.0 (invisible).
+          opacity: _visible ? 1.0 : 0.0,
+          duration: new Duration(milliseconds: 500),
+          // The green box needs to be the child of the AnimatedOpacity
+          child: new MapboxOverlay(
+            controller: controller,
+            options: new MapboxMapOptions(
+              style: Style.outdoors,
+              camera: new CameraPosition(
+                  target: new LatLng(lat: 12.976321, lng: 77.591332),
+                  zoom: 10.0,
+                  bearing: 0.0,
+                  tilt: 0.0),
+            ),
+          ),
+        )
+      ),
+      floatingActionButton: new FloatingActionButton(
+        onPressed: () {
+          // Make sure we call setState! This will tell Flutter to rebuild the
+          // UI with our changes!
+          setState(() {
+            _visible = !_visible;
+          });
+        },
+        tooltip: 'Toggle Opacity',
+        child: new Icon(Icons.flip),
+      ), // This
+    );
+  }
+}

--- a/example/lib/flutter_list.dart
+++ b/example/lib/flutter_list.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_mapbox/controller.dart';
+import 'package:flutter_mapbox/overlay.dart';
+
+class ListDemo extends StatefulWidget {
+  @override
+  _ListDemoState createState() => new _ListDemoState();
+}
+
+class _ListDemoState extends State<ListDemo> {
+  final GlobalKey<AnimatedListState> _listKey =
+      new GlobalKey<AnimatedListState>();
+  ListModel<int> _list;
+  int _selectedItem;
+
+  @override
+  void initState() {
+    super.initState();
+    _list = new ListModel<int>(
+      listKey: _listKey,
+      initialItems: <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+      removedItemBuilder: _buildRemovedItem,
+    );
+  }
+
+  // Used to build list items that haven't been removed.
+  Widget _buildItem(
+      BuildContext context, int index, Animation<double> animation) {
+    if (index == 5)
+      return new MapItem(
+        animation: animation,
+        item: _list[index],
+        selected: _selectedItem == _list[index],
+        onTap: () {
+          setState(() {
+            _selectedItem = _selectedItem == _list[index] ? null : _list[index];
+          });
+        },
+      );
+
+    return new CardItem(
+      animation: animation,
+      item: _list[index],
+      selected: _selectedItem == _list[index],
+      onTap: () {
+        setState(() {
+          _selectedItem = _selectedItem == _list[index] ? null : _list[index];
+        });
+      },
+    );
+  }
+
+
+  Widget _buildRemovedItem(
+      int item, BuildContext context, Animation<double> animation) {
+    return new CardItem(
+      animation: animation,
+      item: item,
+      selected: false,
+      // No gesture detector here: we don't want removed items to be interactive.
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new MaterialApp(
+      home: new Scaffold(
+        appBar: new AppBar(
+          title: const Text('List demo'),
+        ),
+        body: new Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: new AnimatedList(
+            key: _listKey,
+            initialItemCount: _list.length,
+            itemBuilder: _buildItem,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Keeps a Dart List in sync with an AnimatedList.
+///
+/// The [insert] and [removeAt] methods apply to both the internal list and the
+/// animated list that belongs to [listKey].
+///
+/// This class only exposes as much of the Dart List API as is needed by the
+/// sample app. More list methods are easily added, however methods that mutate the
+/// list must make the same changes to the animated list in terms of
+/// [AnimatedListState.insertItem] and [AnimatedList.removeItem].
+class ListModel<E> {
+  ListModel({
+    @required this.listKey,
+    @required this.removedItemBuilder,
+    Iterable<E> initialItems,
+  })  : assert(listKey != null),
+        assert(removedItemBuilder != null),
+        _items = new List<E>.from(initialItems ?? <E>[]);
+
+  final GlobalKey<AnimatedListState> listKey;
+  final dynamic removedItemBuilder;
+  final List<E> _items;
+
+  AnimatedListState get _animatedList => listKey.currentState;
+
+  void insert(int index, E item) {
+    _items.insert(index, item);
+    _animatedList.insertItem(index);
+  }
+
+  E removeAt(int index) {
+    final E removedItem = _items.removeAt(index);
+    if (removedItem != null) {
+      _animatedList.removeItem(index,
+          (BuildContext context, Animation<double> animation) {
+        return removedItemBuilder(removedItem, context, animation);
+      });
+    }
+    return removedItem;
+  }
+
+  int get length => _items.length;
+
+  E operator [](int index) => _items[index];
+
+  int indexOf(E item) => _items.indexOf(item);
+}
+
+class CardItem extends StatelessWidget {
+  const CardItem(
+      {Key key,
+      @required this.animation,
+      this.onTap,
+      @required this.item,
+      this.selected: false})
+      : assert(animation != null),
+        assert(item != null && item >= 0),
+        assert(selected != null),
+        super(key: key);
+
+  final Animation<double> animation;
+  final VoidCallback onTap;
+  final int item;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    TextStyle textStyle = Theme.of(context).textTheme.display1;
+    if (selected)
+      textStyle = textStyle.copyWith(color: Colors.lightGreenAccent[400]);
+    return new Padding(
+      padding: const EdgeInsets.all(2.0),
+      child: new SizeTransition(
+        axis: Axis.vertical,
+        sizeFactor: animation,
+        child: new GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: new SizedBox(
+            height: 128.0,
+            child: new Card(
+              color: Colors.primaries[item % Colors.primaries.length],
+              child: new Center(
+                child: new Text('Item $item', style: textStyle),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Displays its integer item as 'item N' on a Card whose color is based on
+/// the item's value. The text is displayed in bright green if selected is true.
+/// This widget's height is based on the animation parameter, it varies
+/// from 0 to 128 as the animation varies from 0.0 to 1.0.
+class MapItem extends StatelessWidget {
+  const MapItem(
+      {Key key,
+      @required this.animation,
+      this.onTap,
+      @required this.item,
+      this.selected: false})
+      : assert(animation != null),
+        assert(item != null && item >= 0),
+        assert(selected != null),
+        super(key: key);
+
+  final Animation<double> animation;
+  final VoidCallback onTap;
+  final int item;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    TextStyle textStyle = Theme.of(context).textTheme.display1;
+    if (selected)
+      textStyle = textStyle.copyWith(color: Colors.lightGreenAccent[400]);
+    return new Padding(
+      padding: const EdgeInsets.all(2.0),
+      child: new SizeTransition(
+        axis: Axis.vertical,
+        sizeFactor: animation,
+        child: new GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: new SizedBox(
+            height: 128.0,
+            child: new Card(
+              color: Colors.primaries[item % Colors.primaries.length],
+              child: new Center(
+                child: new MapboxOverlay(
+                  controller: new MapboxOverlayController(),
+                  options: new MapboxMapOptions(
+                    style: Style.dark,
+                    camera: new CameraPosition(
+                        target: new LatLng(lat: 52.376316, lng: 4.897801),
+                        zoom: 15.0,
+                        bearing: 0.0,
+                        tilt: 0.0),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/flutter_tabbar.dart
+++ b/example/lib/flutter_tabbar.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_mapbox/controller.dart';
+import 'package:flutter_mapbox/overlay.dart';
+
+class TabBarDemo extends StatelessWidget {
+
+  final MapboxOverlayController controller = new MapboxOverlayController();
+
+  @override
+  Widget build(BuildContext context) {
+    return new MaterialApp(
+      home: new DefaultTabController(
+        length: 3,
+        child: new Scaffold(
+          appBar: new AppBar(
+            bottom: new TabBar(
+              tabs: [
+                new Tab(icon: new Icon(Icons.directions_car)),
+                new Tab(icon: new Icon(Icons.directions_transit)),
+                new Tab(icon: new Icon(Icons.directions_bike)),
+              ],
+            ),
+            title: new Text('Tabs Demo'),
+          ),
+          body: new TabBarView(
+            children: [
+              new MapboxOverlay(
+                controller: controller,
+                options: new MapboxMapOptions(
+                  style: Style.light,
+                  camera: new CameraPosition(
+                      target: new LatLng(lat: 40.717183, lng: -74.000974),
+                      zoom: 8.0,
+                      bearing: 0.0,
+                      tilt: 0.0),
+                ),
+              ),
+              new Icon(Icons.directions_car),
+              new Icon(Icons.directions_transit),
+              new Icon(Icons.directions_bike),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/mapbox_camera.dart
+++ b/example/lib/mapbox_camera.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_mapbox/controller.dart';
+import 'package:flutter_mapbox/overlay.dart';
+
+class CameraDemo extends StatefulWidget {
+  @override
+  _CameraDemoState createState() => new _CameraDemoState();
+}
+
+class _CameraDemoState extends State<CameraDemo> {
+  final MapboxOverlayController controller = new MapboxOverlayController();
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      appBar: new AppBar(
+        title: new Text('Mapbox Flutter Demo'),
+      ),
+      drawer: new Drawer(
+        // Add a ListView to the drawer. This ensures the user can scroll
+        // through the options in the Drawer if there isn't enough vertical
+        // space to fit everything.
+        child: new ListView(
+          // Important: Remove any padding from the ListView.
+          padding: EdgeInsets.zero,
+          children: <Widget>[
+            new DrawerHeader(
+              child: new Text('Drawer Header'),
+              decoration: new BoxDecoration(
+                color: Colors.blue,
+              ),
+            ),
+            new ListTile(
+              title: new Text('jumpTo New York'),
+              onTap: () {
+                controller.jumpTo(new CameraPosition(
+                    target: new LatLng(lat: 40.758896, lng: -73.985130),
+                    zoom: 11.0,
+                    bearing: 0.0,
+                    tilt: 0.0));
+                Navigator.of(context).pop();
+              },
+            ),
+            new ListTile(
+              title: new Text('flyTo Melbourne'),
+              onTap: () {
+                controller.flyTo(
+                    new CameraPosition(
+                        target: new LatLng(lat: -37.8155984, lng: 144.9640312),
+                        zoom: 11.0,
+                        bearing: 0.0,
+                        tilt: 0.0),
+                    3000);
+                Navigator.of(context).pop();
+              },
+            ),
+            new ListTile(
+              title: new Text('easeTo Dubai'),
+              onTap: () {
+                controller.easeTo(
+                    new CameraPosition(
+                        target: new LatLng(lat: 25.276987, lng: 55.296249),
+                        zoom: 11.0,
+                        bearing: 180.0,
+                        tilt: 0.0),
+                    3000,
+                    true);
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        ),
+      ),
+      body: new Container(
+        child: new MapboxOverlay(
+          controller: controller,
+          options: new MapboxMapOptions(
+            style: Style.mapboxStreets,
+            camera: new CameraPosition(
+                target: new LatLng(lat: -37.8155984, lng: 144.9640312),
+                zoom: 11.0,
+                bearing: 0.0,
+                tilt: 0.0),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/mapbox_minmaxzoomlevel.dart
+++ b/example/lib/mapbox_minmaxzoomlevel.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_mapbox/controller.dart';
+import 'package:flutter_mapbox/overlay.dart';
+
+class MinMaxZoomLevelDemo extends StatefulWidget {
+  @override
+  _MinMaxZoomLevelDemoState createState() => new _MinMaxZoomLevelDemoState();
+}
+
+class _MinMaxZoomLevelDemoState extends State<MinMaxZoomLevelDemo> {
+  final MapboxOverlayController controller = new MapboxOverlayController();
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      appBar: new AppBar(
+        title: new Text('Mapbox Flutter Demo'),
+      ),
+      drawer: new Drawer(
+        // Add a ListView to the drawer. This ensures the user can scroll
+        // through the options in the Drawer if there isn't enough vertical
+        // space to fit everything.
+        child: new ListView(
+          // Important: Remove any padding from the ListView.
+          padding: EdgeInsets.zero,
+          children: <Widget>[
+            new DrawerHeader(
+              child: new Text('Drawer Header'),
+              decoration: new BoxDecoration(
+                color: Colors.blue,
+              ),
+            ),
+            new ListTile(
+              title: new Text('setMinZoom(9)'),
+              onTap: () {
+                controller.setMinZoom(9.0);
+                Navigator.of(context).pop();
+              },
+            ),
+            new ListTile(
+              title: new Text('setMaxZoom(11.5)'),
+              onTap: () {
+                controller.setMaxZoom(11.5);
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        ),
+      ),
+      body: new Container(
+        child: new MapboxOverlay(
+          controller: controller,
+          options: new MapboxMapOptions(
+            style: Style.trafficDay,
+            camera: new CameraPosition(
+                target: new LatLng(lat: 35.685670, lng:  139.752793),
+                zoom: 8.0,
+                bearing: 0.0,
+                tilt: 0.0),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
To allow to scale development of this repository, I refactored the example application to show a expandable list of API integrations. Atm two categories exist: `Mapbox API` which contains examples of our API integration and `Flutter integration` which validates if we are correctly integrating into the flutter widget ecosystem. 

![image](https://user-images.githubusercontent.com/2151639/39527086-dcb3ab84-4e20-11e8-98d1-214e6a44aa8e.png)
