### PR TITLE
Add configuration steps to prevent circular reference at compile time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Following examples use Mapbox vector tiles, which require a Mapbox account and a
 - Create a `local.properties` file with the following path: `$project_dir/android/local.properties`
 - Add `mapbox.accessToken="YOUR MAPBOX ACCESS TOKEN"`
  token to the **local.properties** file.
- 
+
 #### Demo app
 
 - Install [Flutter](https://flutter.io/get-started/) and validate its installation with `flutter doctor`
@@ -29,6 +29,11 @@ Following examples use Mapbox vector tiles, which require a Mapbox account and a
 - Add Mapbox dependency and read token value in Android module `build.gradle` file:
 ```
 android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         // ...
         def mapboxAccessToken = localProperties.getProperty('mapbox.accessToken')


### PR DESCRIPTION
Added the configuration required in the build.gradle to prevent this error occuring at compile / runtime with `minSdkVersion` set to `16` (ICS)

The error that occurs without this is as follows:
```[CIRCULAR REFERENCE:com.android.tools.r8.ApiLevelException: Static interface methods are only supported starting with Android N (--min-api 24): com.mapbox.geojson.Geometry com.mapbox.geojson.Geometry.fromJson(java.lang.String)]```

The other pull request addresses the missing important statement from the MainActivity which also prevents compilation :)